### PR TITLE
Allow extra bytes

### DIFF
--- a/test/fixture/messages.js
+++ b/test/fixture/messages.js
@@ -93,6 +93,11 @@ base = writeHeader(AUDIO, 4, 8, 4, 1);
 str = 'af001210';
 writeBody(AUDIO, str, base);
 
+const AUDIO_WITH_EXTRA_BYTES = Buffer.alloc(20);
+base = writeHeader(AUDIO_WITH_EXTRA_BYTES, 4, 8, 4, 1);
+str = 'af0012103FFFFFFF';
+writeBody(AUDIO_WITH_EXTRA_BYTES, str, base);
+
 const VIDEO = Buffer.alloc(58);
 base = writeHeader(VIDEO, 4, 9, 46, 1);
 str = `
@@ -100,6 +105,14 @@ str = `
 000468efbcb0
 `;
 writeBody(VIDEO, str, base);
+
+const VIDEO_WITH_EXTRA_BYTES = Buffer.alloc(62);
+base = writeHeader(VIDEO_WITH_EXTRA_BYTES, 4, 9, 46, 1);
+str = `
+17000000000164001fffe1001a6764001facd940d8117b9210000003001000000303c8f183196001
+000468efbcb03FFFFFFF
+`;
+writeBody(VIDEO_WITH_EXTRA_BYTES, str, base);
 
 const CONNECT_RES = Buffer.alloc(202);
 base = writeHeader(CONNECT_RES, 3, 20, 190, 0);
@@ -137,7 +150,9 @@ module.exports = {
     PUBLISH,
     PARAMS,
     AUDIO,
-    VIDEO
+    AUDIO_WITH_EXTRA_BYTES,
+    VIDEO,
+    VIDEO_WITH_EXTRA_BYTES
   },
   res: {
     S0S1S2,

--- a/test/helper/mock-socket.js
+++ b/test/helper/mock-socket.js
@@ -2,9 +2,10 @@ const {Duplex} = require('stream');
 const {req, res} = require('../fixture/messages');
 
 class MockSocket extends Duplex {
-  constructor(t, options) {
+  constructor(t, options = {}) {
     super(options);
     this.t = t;
+    this.extraBytes = options.extraBytes;
     this.state = 'uninitialized';
   }
 
@@ -20,12 +21,20 @@ class MockSocket extends Duplex {
       return;
     }
     if (this.state === 'params-sent') {
-      this.push(req.AUDIO);
+      if (this.extraBytes) {
+        this.push(req.AUDIO_WITH_EXTRA_BYTES);
+      } else {
+        this.push(req.AUDIO);
+      }
       this.state = 'audio-sent';
       return;
     }
     if (this.state === 'audio-sent') {
-      this.push(req.VIDEO);
+      if (this.extraBytes) {
+        this.push(req.VIDEO_WITH_EXTRA_BYTES);
+      } else {
+        this.push(req.VIDEO);
+      }
       this.state = 'video-sent';
       return;
     }

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -103,3 +103,15 @@ test.cb('createSimpleServer', t => {
   })
   .pipe(new Terminator());
 });
+
+test.cb('Allow extra bytes', t => {
+  const {server} = createServer()
+  .once('/live', factory(t, handleConnection))
+  .on('error', err => {
+    console.error(err.stack);
+    t.fail();
+    t.end();
+  });
+  const socket = new MockSocket(t, {extraBytes: true});
+  server.emit('connection', socket);
+});


### PR DESCRIPTION
Instead of throwing an exception, skip the trailing bytes if any extra/meaningless bytes are found in the buffer.